### PR TITLE
enable and disable rtc calibration registers

### DIFF
--- a/STM32F1/libraries/RTClock/src/utility/rtc_util.c
+++ b/STM32F1/libraries/RTClock/src/utility/rtc_util.c
@@ -53,7 +53,8 @@ void rtc_init(rtc_clk_src src) {
 					// (we reset the backup domain here because we must in order to change the rtc clock source).
 
 	bkp_enable_writes();	// enable writes to the backup registers and the RTC registers via the DBP bit in the PWR control register
-
+	//////////////////////   flush backup area
+	RCC_BASE->BDCR |= RCC_BDCR_RTCSEL;
 	RCC_BASE->BDCR &= ~RCC_BDCR_RTCSEL;
 	switch (src) {
 		case RTCSEL_NONE:
@@ -202,6 +203,26 @@ void rtc_set_prescaler_load(uint32 value) {
 	rtc_exit_config_mode();
 	rtc_wait_finished();
 }
+
+void rtc_enable_calibration(void){
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	bb_peri_set_bit(&BKP_BASE->RTCCR, BKP_RTCCR_CCO_BIT, 1);
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}
+void rtc_disable_calibration(void){
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	bb_peri_set_bit(&BKP_BASE->RTCCR, BKP_RTCCR_CCO_BIT, 0);
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}
+
 
 /**
  * @brief Returns the rtc's prescaler divider (i.e. current divider count) value.

--- a/STM32F1/libraries/RTClock/src/utility/rtc_util.h
+++ b/STM32F1/libraries/RTClock/src/utility/rtc_util.h
@@ -140,6 +140,8 @@ void rtc_detach_interrupt(uint8 interrupt);
 uint32 rtc_get_count();
 void rtc_set_count(uint32 value);
 void rtc_set_prescaler_load(uint32 value);
+void rtc_enable_calibration(void);
+void rtc_disable_calibration(void);
 uint32 rtc_get_divider();
 void rtc_set_alarm(uint32 value);
 


### PR DESCRIPTION
add two functions.
void rtc_enable_calibration(void);
void rtc_disable_calibration(void);

useful rtc calibration. After enabling on PC13 will be found LSE/64 freq.
details
http://www.st.com/resource/en/application_note/cd00167326.pdf
check with logic analyser
work fine

![image](https://user-images.githubusercontent.com/13326299/37787919-b95e8c3e-2e32-11e8-8a95-cbbcc175d4dd.png)
